### PR TITLE
Add Wagtail 5 classifier and remove Python 3.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setuptools.setup(
         'Framework :: Django :: 4.1',
         'Framework :: Wagtail',
         'Framework :: Wagtail :: 4',
+        'Framework :: Wagtail :: 5',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
     python_requires='>=3.7',

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setuptools.setup(
         'Framework :: Wagtail :: 5',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     include_package_data=True,
 )


### PR DESCRIPTION
- Include Wagtail 5 support in setup
- Remove support for Python 3.7